### PR TITLE
Uncover links in reverse order

### DIFF
--- a/examples/sudoku.rs
+++ b/examples/sudoku.rs
@@ -1,0 +1,51 @@
+// Run Sudoku solver
+// Usage:
+// $ cargo run --release --example sudoku 300080900000340000008005600500104070002009010003000040005001200000000000070008090
+
+use dancing_links::{latin_square, ExactCover};
+use dancing_links::sudoku::{Sudoku, Possibility};
+
+fn print_solution(problem: &str, solution: &Vec<&Possibility>) {
+    let mut s: Vec<char> = problem.chars().collect();
+    for poss in solution {
+        s[poss.row * 9 + poss.column] = ('0' as usize + poss.value) as u8 as char;
+    }
+    for i in 0..9 {
+        println!("{}", s[i * 9..(i + 1) * 9].into_iter().collect::<String>());
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 2 {
+        eprintln!("problem needed");
+        std::process::exit(1);
+    }
+
+    let problem = &args[1];
+    if problem.len() != 9 * 9 {
+        eprintln!("invalid problem format");
+        std::process::exit(1);
+    }
+
+    let mut filled = Vec::new();
+    for row in 0..9 {
+        for column in 0..9 {
+            let c = problem.chars().nth(row * 9 + column).unwrap();
+            if c != '0' {
+                let value = c as usize - '0' as usize;
+                filled.push(latin_square::Possibility { row, column, value });
+            }
+        }
+    }
+
+    let sudoku = Sudoku::new(
+        3,
+        filled,
+    );
+    let solver = sudoku.solver();
+    for solution in solver {
+        print_solution(problem, &solution);
+        println!("");
+    }
+}

--- a/src/grid/base_node.rs
+++ b/src/grid/base_node.rs
@@ -78,13 +78,13 @@ impl BaseNode {
                 ..
             } = ptr::read(self_ptr);
 
-            let mut left_node = ptr::read(left_ptr);
-            left_node.right = self_ptr;
-            ptr::write(left_ptr, left_node);
-
             let mut right_node = ptr::read(right_ptr);
             right_node.left = self_ptr;
             ptr::write(right_ptr, right_node);
+
+            let mut left_node = ptr::read(left_ptr);
+            left_node.right = self_ptr;
+            ptr::write(left_ptr, left_node);
         }
     }
 
@@ -96,13 +96,13 @@ impl BaseNode {
                 ..
             } = ptr::read(self_ptr);
 
-            let mut up_node = ptr::read(up_ptr);
-            up_node.down = self_ptr;
-            ptr::write(up_ptr, up_node);
-
             let mut down_node = ptr::read(down_ptr);
             down_node.up = self_ptr;
             ptr::write(down_ptr, down_node);
+
+            let mut up_node = ptr::read(up_ptr);
+            up_node.down = self_ptr;
+            ptr::write(up_ptr, up_node);
         }
     }
 }

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -193,7 +193,7 @@ where
                 FrameState::Uncover => {
                     let (_row_index, columns) = curr_frame.selected_rows.pop_front().unwrap();
 
-                    for column_ptr in columns {
+                    for column_ptr in columns.into_iter().rev() {
                         Column::uncover(column_ptr);
                     }
                     self.partial_solution.pop();


### PR DESCRIPTION
I have encountered assertion failure, same as #4.

It looks something collapse in backtracking,
it is needed to uncover columns in reverse order.

I add an example to run 3x3 Sudoku.
Without this fix, it takes too long (or infinite) to solve the problem:

```sh
$ cargo run --release --example sudoku 300080900000340000008005600500104070002009010003000040005001200000000000070008090
```
